### PR TITLE
docs(readme): fix minor typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ ht.setup {
 -- Toggle a GHCi repl for the current package
 vim.keymap.set('n', '<leader>rr', ht.repl.toggle, def_opts)
 -- Toggle a GHCi repl for the current buffer
-vim.keymap.set('n', '<leader>rf', funciton()
+vim.keymap.set('n', '<leader>rf', function()
   ht.repl.toggle(vim.api.nvim_buf_get_name(0))
 end, def_opts)
 vim.keymap.set('n', '<leader>rq', ht.repl.quit, def_opts)


### PR DESCRIPTION
This typo breaks copy/paste