### PR TITLE
fix(codelens): support proper refreshing

### DIFF
--- a/lua/haskell-tools/lsp.lua
+++ b/lua/haskell-tools/lsp.lua
@@ -19,9 +19,14 @@ end
 
 local function setup_codeLens(opts)
   if opts.autoRefresh then
-    vim.api.nvim_create_autocmd({'FileType', 'BufEnter', 'CursorHold', 'InsertLeave', 'BufWritePost', 'TextChanged'}, {
+    vim.api.nvim_create_autocmd({'FileType'}, {
       pattern = 'haskell',
       group = vim.api.nvim_create_augroup('haskell-tools-code-lens', {}),
+      callback = vim.lsp.codelens.refresh,
+    })
+    vim.api.nvim_create_autocmd({'BufEnter', 'CursorHold', 'InsertLeave', 'BufWritePost', 'TextChanged'}, {
+      pattern = '*.hs',
+      group = vim.api.nvim_create_augroup('haskell-tools-code-lens-2', {}),
       callback = vim.lsp.codelens.refresh,
     })
     vim.lsp.codelens.refresh()


### PR DESCRIPTION
Currently codelenses don't refresh properly since the autocmd pattern isn't correct. The Filetype autocmd should have a `haskell` pattern but the others should have `*.hs`. I found this bug because I would write a line
```haskell
f x = x
```
or
```haskell
-- >>> 3 + 4
```
in a Haskell buffer with HLS enabled and expect the respective code action to appear on `InsertLeave` but it would never happen. With my patch, it seems to work for me. I am also considering just dropping the `FileType` autocmd since it seems unwieldy and unnecessary in most situations.

###### Description of changes

Add new autocmd group that uses the correct pattern for the autocmds.

###### Things done

- [x] Tested, as applicable:
  - [x] Manually
- [x] Updated [CHANGELOG.md](../CHANGELOG.md) (if applicable).
- [x] Fits [CONTRIBUTING.md](https://github.com/MrcJkb/haskell-tools.nvim/blob/master/CONTRIBUTING.md)
