### PR TITLE
fix(log): "toolls" typo in logfile name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.1] - 2023-02-20
+- Fix typo in the logfile name.
+
 ## [1.9.0] - 2023-02-17
 ### Added
 - LSP: Evaluate all code snippets in comments at once.
@@ -13,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Check if attached LSP client supports codeLens before refreshing.
 - Telescope extension can now be registered before haskell-tools has been setup.
-- Fix typo in the logfile name.
 
 ## [1.8.0] - 2023-02-03
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.9.1] - 2023-02-20
+### Fixed
 - Fix typo in the logfile name.
 
 ## [1.9.0] - 2023-02-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Check if attached LSP client supports codeLens before refreshing.
 - Telescope extension can now be registered before haskell-tools has been setup.
+- Fix typo in the logfile name.
 
 ## [1.8.0] - 2023-02-03
 ### Changed

--- a/lua/haskell-tools/log.lua
+++ b/lua/haskell-tools/log.lua
@@ -14,7 +14,7 @@ end
 
 local logpath = vim.fn.stdpath('log')
 vim.fn.mkdir(logpath, 'p')
-local logfilename = logpath .. '/haskell-toolls.log'
+local logfilename = logpath .. '/haskell-tools.log'
 
 ---Get the haskell-tools.nvim log file path.
 ---@return string filepath


### PR DESCRIPTION
###### Description of changes

###### Things done

- [ ] Tested, as applicable:
  - [ ] Manually
  - [ ] Added plenary specs
- [x] Updated [CHANGELOG.md](https://github.com/MrcJkb/haskell-tools.nvim/blob/master/CHANGELOG.md) (if applicable).
- [ ] Fits [CONTRIBUTING.md](https://github.com/MrcJkb/haskell-tools.nvim/blob/master/CONTRIBUTING.md)
