### PR TITLE
docs(readme): correct typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ require('telescope').load_extension('ht')
 For a health check, run `:checkhealth haskell-tools`
 
 #### LSP features not working
-Check which version of GHC you are using (`haskell-language-server-werapper --version`).
+Check which version of GHC you are using (`haskell-language-server-wrapper --version`).
 Sometimes, certain features take some time to be implemented for the latest GHC versions.
 You can see how well a specific GHC version is supported [here](https://haskell-language-server.readthedocs.io/en/latest/support/index.html).
 


### PR DESCRIPTION
###### Description of changes

fixed a typo in the troubleshooting section of the readme