### PR TITLE
feat(hover): hoogle search actions for all detected type signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Improvements to type signature detection from `textDocument/hover` docs.
+
+### Added
+- Hover: Hoogle search entries for all detected type signatures.
+
 ## [1.10.2] - 2023-05-22
 ### Fixed
 - Do not use deprecated health check API in neovim > 0.9.

--- a/lua/haskell-tools/hoogle.lua
+++ b/lua/haskell-tools/hoogle.lua
@@ -19,10 +19,12 @@ local function mk_lsp_hoogle_signature_handler(options)
       vim.notify('hoogle: No information available')
       return
     end
-    local signature = ht_util.try_get_signature_from_markdown(result.contents.value)
-    ht.log.debug { 'Hoogle LSP signature search', signature }
-    if signature ~= '' then
-      handler(signature, options)
+    local func_name = vim.fn.expand('<cword>')
+    local signature_or_func_name = ht_util.try_get_signatures_from_markdown(func_name, result.contents.value)
+      or func_name
+    ht.log.debug { 'Hoogle LSP signature search', signature_or_func_name }
+    if signature_or_func_name ~= '' then
+      handler(signature_or_func_name, options)
     end
   end
 end

--- a/lua/haskell-tools/lsp/hover.lua
+++ b/lua/haskell-tools/lsp/hover.lua
@@ -116,8 +116,9 @@ function hover.on_hover(_, result, ctx, config)
   local to_remove = {}
   local actions = {}
   _state.commands = {}
-  local signature = ht_util.try_get_signature_from_markdown(result.contents.value)
-  if signature and signature ~= '' then
+  local func_name = vim.fn.expand('<cword>')
+  local _, signatures = ht_util.try_get_signatures_from_markdown(func_name, result.contents.value)
+  for _, signature in pairs(signatures) do
     table.insert(actions, 1, string.format('%d. Hoogle search: `%s`', #actions + 1, signature))
     table.insert(_state.commands, function()
       ht.log.debug { 'Hover: Hoogle search for signature', signature }
@@ -125,13 +126,11 @@ function hover.on_hover(_, result, ctx, config)
     end)
   end
   local cword = vim.fn.expand('<cword>')
-  if cword ~= signature then
-    table.insert(actions, 1, string.format('%d. Hoogle search: `%s`', #actions + 1, cword))
-    table.insert(_state.commands, function()
-      ht.log.debug { 'Hover: Hoogle search for cword', cword }
-      ht.hoogle.hoogle_signature { search_term = cword }
-    end)
-  end
+  table.insert(actions, 1, string.format('%d. Hoogle search: `%s`', #actions + 1, cword))
+  table.insert(_state.commands, function()
+    ht.log.debug { 'Hover: Hoogle search for cword', cword }
+    ht.hoogle.hoogle_signature { search_term = cword }
+  end)
   local params = lsp_util.make_position_params()
   local found_location = false
   local found_type_definition = false

--- a/tests/util_spec.lua
+++ b/tests/util_spec.lua
@@ -1,0 +1,22 @@
+local util = require('haskell-tools.util')
+
+describe('Util:', function()
+  it('Can get function signatures from LSP markdown docs', function()
+    -- For some reason, [[ ]] strings do not work here.
+    local doc = '```haskell\n'
+      .. 'someFunc :: forall a. Num a => a -> a\n'
+      .. '```\n'
+      .. '```haskell\n'
+      .. '_ :: Int -> Int\n'
+      .. '```\n'
+      .. '```haskell\n'
+      .. '_ :: forall a. Num a => a -> a\n'
+      .. '```\n'
+    local func_sig, all_signatures = util.try_get_signatures_from_markdown('someFunc', doc)
+    assert.same('Num a => a -> a', func_sig)
+    assert.same({
+      'Num a => a -> a',
+      'Int -> Int',
+    }, all_signatures)
+  end)
+end)


### PR DESCRIPTION
###### Description of changes

* Improvements to type signature detection: Detect all type signatures in `textDocument/hover` docs.
* Hoogle search actions for all detected type signatures

###### Things done

- [x] Tested, as applicable:
  - [x] Manually
  - [x] Added plenary specs
- [x] Updated [CHANGELOG.md](https://github.com/MrcJkb/haskell-tools.nvim/blob/master/CHANGELOG.md) (if applicable).
- [x] Fits [CONTRIBUTING.md](https://github.com/MrcJkb/haskell-tools.nvim/blob/master/CONTRIBUTING.md)
