### PR TITLE
prefer 'stack ghci' over 'cabal repl'

### DIFF
--- a/lua/haskell-tools/repl.lua
+++ b/lua/haskell-tools/repl.lua
@@ -77,11 +77,11 @@ function repl.mk_repl_cmd(file)
       return nil
     end
   end
-  if project.is_cabal_project(chk_path) then
-    return mk_cabal_repl_cmd(file)
-  end
   if project.is_stack_project(chk_path) then
     return mk_stack_repl_cmd(file)
+  end
+  if project.is_cabal_project(chk_path) then
+    return mk_cabal_repl_cmd(file)
   end
   if vim.fn.executable('ghci') == 1 then
     local cmd = vim.tbl_flatten { 'ghci', file and { file } or {} }


### PR DESCRIPTION
A stack project may have a *.cabal file, but that doesn't mean that `cabal repl` will work. For example, some project dependencies may come from internal repositories declared in `stack.yaml`, which cabal doesn't know about. Thus prefer `stack ghci` if `stack.yaml` exists to get a REPL.

<!-- markdownlint-disable -->
###### Description of changes

###### Things done

- [ ] Tested, as applicable:
  - [ ] Manually
  - [ ] Added plenary specs
- [ ] Updated [CHANGELOG.md](https://github.com/MrcJkb/haskell-tools.nvim/blob/master/CHANGELOG.md) (if applicable).
- [ ] Fits [CONTRIBUTING.md](https://github.com/MrcJkb/haskell-tools.nvim/blob/master/CONTRIBUTING.md)
