### PR TITLE
fix(cabal): remove default `cabalFormattingProvider` setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.2] - 2023-11-25
+
+### Fixed
+
+- Remove dafault setting for `cabalFormattingProvider`,
+  falling back to haskell-language-server's default.
+
 ## [3.0.1] - 2023-11-23
 
 ### Fixed

--- a/lua/haskell-tools/config/internal.lua
+++ b/lua/haskell-tools/config/internal.lua
@@ -159,7 +159,6 @@ local HTDefaultConfig = {
       haskell = {
         -- The formatting providers.
         formattingProvider = 'fourmolu',
-        cabalFormattingProvider = 'cabalfmt',
         -- Maximum number of completions sent to the LSP client.
         maxCompletions = 40,
         -- Whether to typecheck the entire project on initial load.


### PR DESCRIPTION
Fixes #191.
Fixes #292.