### PR TITLE
docs(readme): example haskell.lua keymap conflict removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ local bufnr = vim.api.nvim_get_current_buf()
 local opts = { noremap = true, silent = true, buffer = bufnr, }
 -- haskell-language-server relies heavily on codeLenses,
 -- so auto-refresh (see advanced configuration) is enabled by default
-vim.keymap.set('n', '<space>ca', vim.lsp.codelens.run, opts)
+vim.keymap.set('n', '<space>cl', vim.lsp.codelens.run, opts)
 -- Hoogle search for the type signature of the definition under the cursor
 vim.keymap.set('n', '<space>hs', ht.hoogle.hoogle_signature, opts)
 -- Evaluate all code snippets


### PR DESCRIPTION
lspconfig has a keymap of '<space>ca' for code action so '<space>cl' removes this conflict.