### PR TITLE
Fix LSP Snippets Issue

### DIFF
--- a/lua/haskell-tools/config/internal.lua
+++ b/lua/haskell-tools/config/internal.lua
@@ -34,10 +34,10 @@ local folding_range_capabilities = deps.if_available('ufo', function(_)
 end, {})
 local capabilities = vim.tbl_deep_extend(
   'keep',
-  ht_capabilities,
   cmp_capabilities,
   selection_range_capabilities,
-  folding_range_capabilities
+  folding_range_capabilities,
+  ht_capabilities
 )
 
 ---@class HTConfig haskell-tools.nvim plugin configuration.


### PR DESCRIPTION
This PR fixes an issue where LSP snippets were not working. The default capabilities from `﻿vim.lsp.protocol.make_client_capabilities() `were taking precedence over those from `﻿cmp_nvim_lsp.default_capabilities()`. The merge order has been updated to ensure ﻿`cmp_nvim_lsp.default_capabilities()` takes precedence.