### PR TITLE
fix: many typos

### DIFF
--- a/doc/haskell-tools.txt
+++ b/doc/haskell-tools.txt
@@ -126,7 +126,7 @@ haskell-tools.hover.Opts                              *haskell-tools.hover.Opts*
         {stylize_markdown?}  (boolean)
                                                       (default: `false`) The builtin LSP client's default behaviour is to stylize markdown.
                                                       Setting this option to false sets the file type to markdown
-                                                      and enables treesitter syntax highligting for Haskell snippets if nvim-treesitter is installed.
+                                                      and enables treesitter syntax highlighting for Haskell snippets if nvim-treesitter is installed.
         {auto_focus?}        (boolean)
                                                       (default: `false`) Whether to automatically switch to the hover window.
 

--- a/lua/haskell-tools/commands.lua
+++ b/lua/haskell-tools/commands.lua
@@ -81,7 +81,7 @@ local function register_subcommand_tbl(name, subcmd_tbl)
         vim.notify(
           ([[
 Haskell %s: Expected subcommand.
-Avaiable subcommands:
+Available subcommands:
 %s
 ]]):format(name, table.concat(vim.tbl_keys(subcmd_tbl), ', ')),
           vim.log.levels.ERROR

--- a/lua/haskell-tools/config/init.lua
+++ b/lua/haskell-tools/config/init.lua
@@ -94,7 +94,7 @@ vim.g.haskell_tools = vim.g.haskell_tools
 ---
 ---(default: `false`) The builtin LSP client's default behaviour is to stylize markdown.
 ---Setting this option to false sets the file type to markdown
----and enables treesitter syntax highligting for Haskell snippets if nvim-treesitter is installed.
+---and enables treesitter syntax highlighting for Haskell snippets if nvim-treesitter is installed.
 ---@field stylize_markdown? boolean
 ---
 ---(default: `false`) Whether to automatically switch to the hover window.

--- a/lua/haskell-tools/config/internal.lua
+++ b/lua/haskell-tools/config/internal.lua
@@ -73,7 +73,7 @@ local HTDefaultConfig = {
         { '╰', 'FloatBorder' },
         { '│', 'FloatBorder' },
       },
-      ---@type boolean (default: `false`) The builtin LSP client's default behaviour is to stylize markdown. Setting this option to false sets the file type to markdown and enables treesitter syntax highligting for Haskell snippets if nvim-treesitter is installed.
+      ---@type boolean (default: `false`) The builtin LSP client's default behaviour is to stylize markdown. Setting this option to false sets the file type to markdown and enables treesitter syntax highlighting for Haskell snippets if nvim-treesitter is installed.
       stylize_markdown = false,
       ---@type boolean (default: `false`) Whether to automatically switch to the hover window.
       auto_focus = false,

--- a/lua/haskell-tools/config/internal.lua
+++ b/lua/haskell-tools/config/internal.lua
@@ -190,7 +190,7 @@ local HTDefaultConfig = {
               exception = true,
             },
           },
-          excplicitFixity = { globalOn = true },
+          explicitFixity = { globalOn = true },
           gadt = { globalOn = true },
           ['ghcide-code-actions-bindings'] = { globalOn = true },
           ['ghcide-code-actions-fill-holes'] = { globalOn = true },

--- a/lua/haskell-tools/health.lua
+++ b/lua/haskell-tools/health.lua
@@ -127,7 +127,7 @@ local external_dependencies = {
       return not hoogle_mode or hoogle_mode ~= 'telescope-web'
     end,
     url = '[curl](https://curl.se/)',
-    info = 'Required for "telescope-web" hoogle seach mode.',
+    info = 'Required for "telescope-web" hoogle search mode.',
   },
   {
     name = 'haskell-debug-adapter',

--- a/lua/haskell-tools/hoogle/helpers.lua
+++ b/lua/haskell-tools/hoogle/helpers.lua
@@ -19,7 +19,7 @@ local entry_display = deps.require_telescope('telescope.pickers.entry_display')
 ---@class haskell-tools.hoogle.Helpers
 local Helpers = {}
 
----@param buf number the telescope buffebuffer numberr
+---@param buf number the telescope buffebuffer number
 ---@param map fun(mode:string,keys:string,action:function) callback for creating telescope keymaps
 ---@return boolean
 function Helpers.hoogle_attach_mappings(buf, map)

--- a/lua/haskell-tools/hoogle/web.lua
+++ b/lua/haskell-tools/hoogle/web.lua
@@ -35,7 +35,7 @@ end
 ---@class haskell-tools.hoogle.web-search.Opts
 ---@field base_url string|nil The base URL of the hoogle server
 ---@field scope string|nil The scope of the search
----@field json boolean|nil Whather to request JSON enocded results
+---@field json boolean|nil Whether to request JSON encoded results
 
 ---Build a Hoogle request URL
 ---@param search_term string

--- a/lua/haskell-tools/lsp/helpers.lua
+++ b/lua/haskell-tools/lsp/helpers.lua
@@ -26,7 +26,7 @@ function LspHelpers.get_active_haskell_clients(bufnr)
 end
 
 ---@param bufnr number the buffer to get clients for
----@return vim.lsp.Client[] cabal_clinets
+---@return vim.lsp.Client[] cabal_clients
 ---@see util.get_clients
 function LspHelpers.get_active_cabal_clients(bufnr)
   return LspHelpers.get_clients { bufnr = bufnr, name = LspHelpers.cabal_client_name }

--- a/lua/haskell-tools/lsp/hover.lua
+++ b/lua/haskell-tools/lsp/hover.lua
@@ -265,7 +265,7 @@ function hover.on_hover(_, result, ctx, config)
       close_hover()
     end
     table.insert(_state.commands, references_action)
-    create_plug_mapping('Referenes', references_action, current_bufnr)
+    create_plug_mapping('References', references_action, current_bufnr)
     ::SkipDefinition::
     if found_type_definition then
       goto SkipTypeDefinition

--- a/lua/haskell-tools/lsp/init.lua
+++ b/lua/haskell-tools/lsp/init.lua
@@ -31,7 +31,7 @@ end
 ---A workaround for #48:
 ---Some plugins that add LSP client capabilities which are not built-in to neovim
 ---(like nvim-ufo and nvim-lsp-selection-range) cause error messages, because
----haskell-language-server falsly advertises those server_capabilities for cabal files.
+---haskell-language-server falsely advertises those server_capabilities for cabal files.
 ---@param client vim.lsp.Client
 ---@return nil
 local function fix_cabal_client(client)

--- a/lua/haskell-tools/repl/toggleterm.lua
+++ b/lua/haskell-tools/repl/toggleterm.lua
@@ -109,7 +109,7 @@ return function(mk_repl_cmd, opts)
   end
 
   ---Quit the repl
-  ---@retrun nil
+  ---@return nil
   function ReplHandlerImpl.quit()
     if ReplHandlerImpl.terminal ~= nil then
       log.debug('repl.toggleterm: sending quit to repl.')

--- a/lua/telescope/_extensions/ht.lua
+++ b/lua/telescope/_extensions/ht.lua
@@ -1,6 +1,6 @@
 ---@mod haskell-tools.telescope-extension haskell-tools Telescope extension
 ---@brief [[
---- If `telescope.nvim` is installed, `haskell-tools` will register the `ht` extenstion
+--- If `telescope.nvim` is installed, `haskell-tools` will register the `ht` extension
 --- with the following commands:
 ---
 --- * `:Telescope ht package_files` - Search for files within the current (sub)package.


### PR DESCRIPTION
Fix some typos.
Since this involves breaking changes such as changing the option name,
I think it would be better to leave the mistyped option name and mark it as deprecated in LuaLS.

e.g.

### `lua/haskell-tools/config/internal.lua`

```lua
-- ....
              exception = true,
             },
           },
           ---@deprecated -- add it
           excplicitFixity = { globalOn = true },
           explicitFixity = { globalOn = true },
           gadt = { globalOn = true },
           ['ghcide-code-actions-bindings'] = { globalOn = true },
           ['ghcide-code-actions-fill-holes'] = { globalOn = true },
--- ....
```

https://github.com/mrcjkb/haskell-tools.nvim/commit/e6e38c05d5c1139b7ca10b5e5033074141d87531