### PR TITLE
feat!(lsp): use `vim.lsp.config['haskell-tools']` to fix conflict with nvim-lspconfig

### DIFF
--- a/lua/haskell-tools/lsp/init.lua
+++ b/lua/haskell-tools/lsp/init.lua
@@ -171,7 +171,7 @@ Hls.start = function(bufnr)
       fix_cabal_client(client)
     end,
   }
-  local client_config = vim.tbl_deep_extend('force', {}, lsp_start_opts, vim.lsp.config['hls'] or {})
+  local client_config = vim.tbl_deep_extend('force', {}, lsp_start_opts, vim.lsp.config['haskell-tools'] or {})
   local client_id = vim.lsp.start(client_config)
   return client_id
 end


### PR DESCRIPTION
Closes #465.

nvim-lspconfig has a `lsp/hls.lua` file that automatically gets sourced and causes this plugin's config to be overridden.
Instead of using `vim.lsp.config['hls']`, this plugin now uses `vim.lsp.config['haskell-tools']` to avoid this conflict.