### PR TITLE
fix!: priorizite hie.yaml in package root search

### DIFF
--- a/lua/haskell-tools/project/init.lua
+++ b/lua/haskell-tools/project/init.lua
@@ -64,10 +64,10 @@ local Project = {}
 ---@return string|nil
 Project.root_dir = function(project_file)
   local HtProjectHelpers = require('haskell-tools.project.helpers')
-  return HtProjectHelpers.match_cabal_project_root(project_file)
+  return HtProjectHelpers.match_hie_yaml(project_file)
+    or HtProjectHelpers.match_cabal_project_root(project_file)
     or HtProjectHelpers.match_stack_project_root(project_file)
     or HtProjectHelpers.match_package_root(project_file)
-    or HtProjectHelpers.match_hie_yaml(project_file)
 end
 
 ---Open the package.yaml of the package containing the current buffer.


### PR DESCRIPTION
Reorder the files used to find the root directory of the project to prioritize `hie.yaml`. See #505 