### PR TITLE
fix(lsp): broken go-to-<location> hover-action/hoogle-fallback handlers

### DIFF
--- a/lua/haskell-tools/lsp/definition.lua
+++ b/lua/haskell-tools/lsp/definition.lua
@@ -14,11 +14,13 @@ local lsp_definition = {}
 ---@param opts table<string,any>|nil
 ---@return lsp.Handler
 function lsp_definition.mk_hoogle_fallback_definition_handler(opts)
-  return function(_, result, ...)
+  return function(_, result, ctx, ...)
     local ht = require('haskell-tools')
     if #result > 0 then
-      local default_handler = vim.lsp.handlers[vim.lsp.protocol.Methods.textDocument_definition]
-      return default_handler(_, result, ...)
+      local client = vim.lsp.get_client_by_id(ctx.client_id)
+      local encoding = client and client.offset_encoding or 'utf-8'
+      vim.lsp.util.show_document(result[1], encoding, { focus = true })
+      return
     end
     log.debug('Definition not found. Falling back to Hoogle search.')
     vim.notify('Definition not found. Falling back to Hoogle search...', vim.log.levels.WARN)

--- a/lua/haskell-tools/lsp/hover.lua
+++ b/lua/haskell-tools/lsp/hover.lua
@@ -229,13 +229,10 @@ function hover.on_hover(_, result, ctx, config)
             table.insert(actions, 1, string.format('%d. Go to definition at ' .. location_suffix, #actions + 1))
             local action = function()
               -- We don't call vim.lsp.buf.definition() because the location params may have changed
-              local definition_ctx = vim.tbl_extend('force', ctx, {
-                method = vim.lsp.protocol.Methods.textDocument_definition,
-              })
               log.debug { 'Hover: Go to definition', definition_result }
-              ---Neovim 0.9 has a bug in the lua doc
-              ---@diagnostic disable-next-line: param-type-mismatch
-              vim.lsp.handlers[vim.lsp.protocol.Methods.textDocument_definition](nil, definition_result, definition_ctx)
+              local client = vim.lsp.get_client_by_id(ctx.client_id)
+              local encoding = client and client.offset_encoding or 'utf-8'
+              vim.lsp.util.show_document(definition_result, encoding, { focus = true })
               close_hover()
             end
             table.insert(_state.commands, action)
@@ -276,17 +273,10 @@ function hover.on_hover(_, result, ctx, config)
             table.insert(actions, 1, string.format('%d. Go to type definition at ' .. type_def_suffix, #actions + 1))
             local typedef_action = function()
               -- We don't call vim.lsp.buf.typeDefinition() because the location params may have changed
-              local type_definition_ctx = vim.tbl_extend('force', ctx, {
-                method = vim.lsp.protocol.Methods.textDocument_typeDefinition,
-              })
               log.debug { 'Hover: Go to type definition', type_definition_result }
-              ---Neovim 0.9 has a bug in the lua doc
-              ---@diagnostic disable-next-line: param-type-mismatch
-              vim.lsp.handlers[vim.lsp.protocol.Methods.textDocument_typeDefinition](
-                nil,
-                type_definition_result,
-                type_definition_ctx
-              )
+              local client = vim.lsp.get_client_by_id(ctx.client_id)
+              local encoding = client and client.offset_encoding or 'utf-8'
+              vim.lsp.util.show_document(type_definition_result, encoding, { focus = true })
               close_hover()
             end
             table.insert(_state.commands, typedef_action)


### PR DESCRIPTION
## Summary

Fixes #528

In Neovim 0.11+, `vim.lsp.handlers["textDocument/definition"]` and `vim.lsp.handlers["textDocument/typeDefinition"]` are `nil`, causing "attempt to call a nil value" errors in three places:

- **`lsp/hover.lua:238`** — "Go to definition" hover action
- **`lsp/hover.lua:285-289`** — "Go to type definition" hover action
- **`lsp/definition.lua:20`** — Hoogle fallback definition handler

All three call sites invoked `vim.lsp.handlers[method](...)` to jump to an already-resolved LSP location. Since the location is already available from `buf_request_sync` / `buf_request_all`, the handler indirection isn't needed.

## Fix

Replace all three with `vim.lsp.util.show_document(result, encoding, { focus = true })`, which directly jumps to the location. This API has been stable since Neovim 0.10.

(`vim.lsp.util.jump_to_location` also works but is itself deprecated and scheduled for removal in 0.12 — it just calls `show_document` internally.)

## Test plan

- [x] Open a Haskell file — HLS attaches normally
- [x] `:Haskell hover` on a symbol — hover actions menu appears
- [x] Select "Go to definition" from hover actions — jumps correctly
- [x] Select "Go to type definition" from hover actions — jumps correctly
- [x] `:Haskell definition` on an unknown symbol — falls back to Hoogle search

Tested on Neovim 0.11.6.