### PR TITLE
feat(lsp)!: single client for haskell and cabal files

### DIFF
--- a/lua/haskell-tools/commands.lua
+++ b/lua/haskell-tools/commands.lua
@@ -142,7 +142,7 @@ local hls_subcommands = {
   stop = {
     impl = function()
       local LspHelpers = require('haskell-tools.lsp.helpers')
-      local hls_clients = LspHelpers.get_active_ht_clients(0)
+      local hls_clients = LspHelpers.get_active_hls_clients(0)
       for _, client in ipairs(hls_clients) do
         vim.cmd.lsp { 'stop', client.name }
       end
@@ -151,7 +151,7 @@ local hls_subcommands = {
   restart = {
     impl = function()
       local LspHelpers = require('haskell-tools.lsp.helpers')
-      local hls_clients = LspHelpers.get_active_ht_clients(0)
+      local hls_clients = LspHelpers.get_active_hls_clients(0)
       for _, client in ipairs(hls_clients) do
         vim.cmd.lsp { 'restart', client.name }
       end
@@ -161,7 +161,7 @@ local hls_subcommands = {
 
 ---@return boolean tf True if the current buffer has an active haskell-language-server LSP client
 local function buf_has_active_hls_client()
-  local hls_clients = require('haskell-tools.lsp.helpers').get_active_ht_clients(0)
+  local hls_clients = require('haskell-tools.lsp.helpers').get_active_hls_clients(0)
   return #hls_clients > 0
 end
 

--- a/lua/haskell-tools/hoogle/init.lua
+++ b/lua/haskell-tools/hoogle/init.lua
@@ -106,7 +106,7 @@ Hoogle.hoogle_signature = function(options)
     return
   end
   local LspHelpers = require('haskell-tools.lsp.helpers')
-  local clients = LspHelpers.get_active_haskell_clients(vim.api.nvim_get_current_buf())
+  local clients = LspHelpers.get_active_hls_clients(vim.api.nvim_get_current_buf())
   if #clients > 0 then
     lsp_hoogle_signature(options, clients[1].offset_encoding)
   else

--- a/lua/haskell-tools/lsp/eval.lua
+++ b/lua/haskell-tools/lsp/eval.lua
@@ -44,7 +44,7 @@ end
 ---@return nil
 function eval.all(bufnr)
   bufnr = bufnr or vim.api.nvim_win_get_buf(0)
-  local clients = LspHelpers.get_active_ht_clients(bufnr)
+  local clients = LspHelpers.get_active_hls_clients(bufnr)
   if not clients or #clients == 0 then
     vim.notify('No haskell-tools LSP client attached.', vim.log.levels.ERROR)
     return

--- a/lua/haskell-tools/lsp/helpers.lua
+++ b/lua/haskell-tools/lsp/helpers.lua
@@ -16,32 +16,12 @@ local LspHelpers = {}
 LspHelpers.get_clients = vim.lsp.get_clients
 
 LspHelpers.haskell_client_name = 'haskell-tools.nvim'
-LspHelpers.cabal_client_name = 'haskell-tools.nvim (cabal)'
 
 ---@param bufnr number the buffer to get clients for
 ---@return vim.lsp.Client[] haskell_clients
 ---@see util.get_clients
-function LspHelpers.get_active_haskell_clients(bufnr)
+function LspHelpers.get_active_hls_clients(bufnr)
   return LspHelpers.get_clients { bufnr = bufnr, name = LspHelpers.haskell_client_name }
-end
-
----@param bufnr number the buffer to get clients for
----@return vim.lsp.Client[] cabal_clients
----@see util.get_clients
-function LspHelpers.get_active_cabal_clients(bufnr)
-  return LspHelpers.get_clients { bufnr = bufnr, name = LspHelpers.cabal_client_name }
-end
-
----@param bufnr number the buffer to get clients for
----@return vim.lsp.Client[] ht_clients The haskell + cabal clients
----@see util.get_clients
----@see util.get_active_haskell_clients
----@see util.get_active_cabal_clients
-function LspHelpers.get_active_ht_clients(bufnr)
-  local clients = {}
-  vim.list_extend(clients, LspHelpers.get_active_haskell_clients(bufnr))
-  vim.list_extend(clients, LspHelpers.get_active_cabal_clients(bufnr))
-  return clients
 end
 
 ---@return string[] cmd The command to invoke haskell-language-server

--- a/lua/haskell-tools/lsp/hover.lua
+++ b/lua/haskell-tools/lsp/hover.lua
@@ -354,7 +354,7 @@ end
 --- Sends the request to hls to get hover actions and handle it
 function hover.hover_actions()
   local LspHelpers = require('haskell-tools.lsp.helpers')
-  local clients = LspHelpers.get_active_haskell_clients(vim.api.nvim_get_current_buf())
+  local clients = LspHelpers.get_active_hls_clients(vim.api.nvim_get_current_buf())
   if #clients == 0 then
     return
   end

--- a/lua/haskell-tools/lsp/init.lua
+++ b/lua/haskell-tools/lsp/init.lua
@@ -31,24 +31,6 @@ local function ensure_clean_exit_on_quit(client, bufnr)
   })
 end
 
----A workaround for #48:
----Some plugins that add LSP client capabilities which are not built-in to neovim
----(like nvim-ufo and nvim-lsp-selection-range) cause error messages, because
----haskell-language-server falsely advertises those server_capabilities for cabal files.
----@param client vim.lsp.Client
----@return nil
-local function fix_cabal_client(client)
-  local LspHelpers = require('haskell-tools.lsp.helpers')
-  if client.name == LspHelpers.cabal_client_name and client.server_capabilities then
-    ---@diagnostic disable-next-line: inject-field
-    client.server_capabilities = vim.tbl_extend('force', client.server_capabilities, {
-      foldingRangeProvider = false,
-      selectionRangeProvider = false,
-      documentHighlightProvider = false,
-    })
-  end
-end
-
 ---@class haskell-tools.load_hls_settings.Opts
 ---@field settings_file_pattern string|nil File name or pattern to search for. Defaults to 'hls.json'
 
@@ -109,9 +91,7 @@ Hls.start = function(bufnr)
     log.debug('lsp.start: ' .. msg)
     return
   end
-  local HtProjectHelpers = require('haskell-tools.project.helpers')
   local LspHelpers = require('haskell-tools.lsp.helpers')
-  local is_cabal = HtProjectHelpers.is_cabal_file(bufnr)
   local project_root = ht.project.root_dir(file)
   local hls_settings = type(hls_opts.settings) == 'function' and hls_opts.settings(project_root) or hls_opts.settings
 
@@ -122,10 +102,10 @@ Hls.start = function(bufnr)
   end
 
   local lsp_start_opts = {
-    name = is_cabal and LspHelpers.cabal_client_name or LspHelpers.haskell_client_name,
+    name = LspHelpers.haskell_client_name,
     cmd = Types.evaluate(cmd),
     root_dir = project_root,
-    filetypes = is_cabal and { 'cabal', 'cabalproject' } or { 'haskell', 'lhaskell' },
+    filetypes = { 'haskell', 'lhaskell', 'cabal', 'cabalproject' },
     capabilities = hls_opts.capabilities,
     handlers = handlers,
     settings = hls_settings,
@@ -146,7 +126,6 @@ Hls.start = function(bufnr)
     end,
     on_init = function(client, _)
       ensure_clean_exit_on_quit(client, bufnr)
-      fix_cabal_client(client)
     end,
   }
   local hs_config_name = lsp_start_opts.name


### PR DESCRIPTION
Reverts the changes introduced in #224.
The HLS bug that caused a need for this no longer appears to be present. Using separate clients meant that changes made to Cabal files weren't noticed by Haskell file clients until the Haskell files were reloaded.