### PR TITLE
fix(lsp): mark inlayHint method as unsupported in cabal files

### DIFF
--- a/lua/haskell-tools/lsp/init.lua
+++ b/lua/haskell-tools/lsp/init.lua
@@ -125,6 +125,24 @@ Hls.start = function(bufnr)
       end
     end,
     on_init = function(client, _)
+      -- FIX: HLS has the (arguably) bug where it advertises support for inlay hints,
+      -- but errors if requested for cabal files.
+      -- As a workaround, we explicitly disable inlay hints for cabal files.
+      local original_supports_method = client.supports_method
+      client.supports_method = function(self, method, buf)
+        if method == 'textDocument/inlayHint' then
+          if buf == nil then
+            buf = vim.api.nvim_get_current_buf()
+          end
+          if vim.api.nvim_buf_is_valid(buf) then
+            local ft = vim.bo[buf].filetype
+            if ft == 'cabal' or ft == 'cabalproject' then
+              return false
+            end
+          end
+        end
+        return original_supports_method(self, method, buf)
+      end
       ensure_clean_exit_on_quit(client, bufnr)
     end,
   }

--- a/lua/haskell-tools/lsp/init.lua
+++ b/lua/haskell-tools/lsp/init.lua
@@ -121,7 +121,7 @@ Hls.start = function(bufnr)
       end
       local code_lens_opts = tools_opts.codeLens or {}
       if Types.evaluate(code_lens_opts.autoRefresh) then
-        vim.lsp.codelens.enable(true, { buffer = bufnr })
+        vim.lsp.codelens.enable(true, { bufnr = buf })
       end
     end,
     on_init = function(client, _)


### PR DESCRIPTION
We override the `client.supports_method` method to selectively disable inlay hints only in cabal buffers. 
This stops HLS from spewing errors when nvim tries to request inlay hints in cabal files, which it does not support (but nvim believes it does, since it reports such a capability meant only for haskell files).

PS. I have not had time to test, but this may be a regression introduced by #559 

PPS. there's a second commit that fixes what appears to be a typo. lmk if i should drop that commit

edit: did not see your latest comment in #485 in time :p