### PR TITLE
Fix: Add setup function

### DIFF
--- a/lua/haskell-tools/init.lua
+++ b/lua/haskell-tools/init.lua
@@ -53,6 +53,9 @@ local HaskellTools = {
   dap = lazy_require('haskell-tools.dap'),
   ---@type haskell-tools.Log
   log = lazy_require('haskell-tools.log'),
+  setup = function(opts)
+    vim.g.haskell_tools = opts
+  end,
 }
 
 return HaskellTools


### PR DESCRIPTION
This probably fixes #711

LazyVim provides `haskell-tools.nvim` as an extra [LazyVim/lua/lazyvim/plugins/extras/lang/haskell.lua:15](https://github.com/LazyVim/LazyVim/blob/999700997f72227187d49d8b92667183dc7fc809/lua/lazyvim/plugins/extras/lang/haskell.lua#L15)

The [README for lazy.nvim](https://github.com/folke/lazy.nvim/blob/306a05526ada86a7b30af95c5cc81ffba93fef97/doc/lazy.nvim.txt#L322) says that it's preferable to use `opts`

and whenever `opts` is defined, `setup` is called: https://github.com/folke/lazy.nvim/blob/306a05526ada86a7b30af95c5cc81ffba93fef97/lua/lazy/core/loader.lua#L387